### PR TITLE
Modify __resolv_conf function

### DIFF
--- a/iocage
+++ b/iocage
@@ -2170,13 +2170,7 @@ EOT
 
 # This is mostly for pkg autoinstall
 __resolv_conf () {
-cat << EOT
-# OpenNIC servers
-nameserver 31.31.78.39
-nameserver 50.116.23.211
-nameserver 151.236.6.6
-nameserver 173.230.156.28
-EOT
+cat /etc/resolv.conf
 }
 
 __help () {


### PR DESCRIPTION
I modified the __resolv_conf function to permit a better usage of iocage.
Instead of Using OpenNIC DNS, Jails will use resolv.conf of the host system
