### PR TITLE
Prevent prompting for pool during boot

### DIFF
--- a/iocage
+++ b/iocage
@@ -1403,15 +1403,21 @@ __find_mypool () {
     done
 
     if [ $found -ne 1 ] ; then
-        echo -n "  please select a pool for iocage jails [$i]: "
-        read answer
+        if [ -n "$RC_PID" ]; then
+            # RC_PID set means we are running from rc
+            echo "ERROR: No pool for iocage jails found on boot ..exiting"
+            exit 1
+        else
+            echo -n "  please select a pool for iocage jails [$i]: "
+            read answer
 
-        if [ -z "$answer" ] ; then
-            answer=$i
+            if [ -z "$answer" ] ; then
+                answer=$i
+            fi
+
+            zpool set comment=iocage $answer
+            export pool=$answer
         fi
-
-        zpool set comment=iocage $answer
-        export pool=$answer
     fi
 }
 


### PR DESCRIPTION
In __find_mypool, prevent prompting if run from rc. Makes no sense anyway, since if there is no pool prepared for iocage in the first place, there won't be any jails to run on boot either. Only caused trouble on a server with SSH-only access, no physical access, with a dangling iocage in the background interfering with proper rc.shutdown invocation upon reboot.
