### PR TITLE
Symlink tag to uuid

### DIFF
--- a/iocage
+++ b/iocage
@@ -664,7 +664,7 @@ __configure_jail () {
         eval prop="\$${prop}"
         if [ ! -z "$prop" ] && [ "$prop" != "readonly" ] ; then
             zfs set $prop_name="$prop" $1
-fi
+        fi
     done
 }
 


### PR DESCRIPTION
I have added functionality to automatically keep track of tags and create/update/delete symlinks from /iocage/tags/<tagname> to the corresponding /iocage/jails/<uuid>. Can be handy for additional scripting to access jail root dirs by easy to remember tag names. What do you think?
