### PR TITLE
Fixes issue with no IPv6 in __legacy_start

### DIFF
--- a/iocage
+++ b/iocage
@@ -50,6 +50,13 @@ else
     vnet="off"
 fi
 
+# see if there is ipv6 support (for shared mode networking)
+if [ ! -z $(sysctl -qn security.jail.param.ip6.addr) ] ; then
+    ipv6="on"
+else
+    ipv6="off"
+fi
+
 interfaces="vnet0:bridge0,vnet1:bridge1"
 host_hostname=$uuid
 exec_fib=0
@@ -1093,46 +1100,86 @@ __legacy_start () {
         ip6_addr=""
     fi
 
-    jail -c \
-    ip4.addr="$ip4_addr" \
-    ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
-    ip4="$(__get_jail_prop ip4 $name)" \
-    ip6.addr="$ip6_addr" \
-    ip6.saddrsel="$(__get_jail_prop ip6_saddrsel $name)" \
-    ip6="$(__get_jail_prop ip6 $name)" \
-    name="ioc-$(__get_jail_prop host_hostuuid $name)" \
-    host.hostname="$(__get_jail_prop hostname $name)" \
-    path="${jail_path}/root" \
-    securelevel="$(__get_jail_prop securelevel $name)" \
-    host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
-    devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
-    enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
-    children.max="$(__get_jail_prop children_max $name)" \
-    allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
-    allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
-    allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
-    allow.chflags="$(__get_jail_prop allow_chflags $name)" \
-    allow.mount="$(__get_jail_prop allow_mount $name)" \
-    allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
-    allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
-    allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
-    allow.mount.tmpfs="$(__get_jail_prop allow_mount_tmpfs $name)" \
-    allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
-    allow.quotas="$(__get_jail_prop allow_quotas $name)" \
-    allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
-    exec.prestart="$(__findscript $name prestart)" \
-    exec.poststart="$(__findscript $name poststart)" \
-    exec.prestop="$(__findscript $name prestop)" \
-    exec.stop="$(__get_jail_prop exec_stop $name)" \
-    exec.clean="$(__get_jail_prop exec_clean $name)" \
-    exec.timeout="$(__get_jail_prop exec_timeout $name)" \
-    stop.timeout="$(__get_jail_prop stop_timeout $name)" \
-    mount.fstab="/iocage/jails/$name/fstab" \
-    mount.devfs="$(__get_jail_prop mount_devfs $name)" \
-    mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
-    allow.dying \
-    exec.consolelog="/iocage/log/${name}-console.log" \
-    persist
+    if [ $ipv6 == "on" ] ; then
+        jail -c \
+        ip4.addr="$ip4_addr" \
+        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
+        ip4="$(__get_jail_prop ip4 $name)" \
+        ip6.addr="$ip6_addr" \
+        ip6.saddrsel="$(__get_jail_prop ip6_saddrsel $name)" \
+        ip6="$(__get_jail_prop ip6 $name)" \
+        name="ioc-$(__get_jail_prop host_hostuuid $name)" \
+        host.hostname="$(__get_jail_prop hostname $name)" \
+        path="${jail_path}/root" \
+        securelevel="$(__get_jail_prop securelevel $name)" \
+        host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
+        devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
+        enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
+        children.max="$(__get_jail_prop children_max $name)" \
+        allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
+        allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
+        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
+        allow.chflags="$(__get_jail_prop allow_chflags $name)" \
+        allow.mount="$(__get_jail_prop allow_mount $name)" \
+        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
+        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
+        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
+        allow.mount.tmpfs="$(__get_jail_prop allow_mount_tmpfs $name)" \
+        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
+        allow.quotas="$(__get_jail_prop allow_quotas $name)" \
+        allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
+        exec.prestart="$(__findscript $name prestart)" \
+        exec.poststart="$(__findscript $name poststart)" \
+        exec.prestop="$(__findscript $name prestop)" \
+        exec.stop="$(__get_jail_prop exec_stop $name)" \
+        exec.clean="$(__get_jail_prop exec_clean $name)" \
+        exec.timeout="$(__get_jail_prop exec_timeout $name)" \
+        stop.timeout="$(__get_jail_prop stop_timeout $name)" \
+        mount.fstab="/iocage/jails/$name/fstab" \
+        mount.devfs="$(__get_jail_prop mount_devfs $name)" \
+        mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
+        allow.dying \
+        exec.consolelog="/iocage/log/${name}-console.log" \
+        persist
+    else
+        jail -c \
+        ip4.addr="$ip4_addr" \
+        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
+        ip4="$(__get_jail_prop ip4 $name)" \
+        name="ioc-$(__get_jail_prop host_hostuuid $name)" \
+        host.hostname="$(__get_jail_prop hostname $name)" \
+        path="${jail_path}/root" \
+        securelevel="$(__get_jail_prop securelevel $name)" \
+        host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
+        devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
+        enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
+        children.max="$(__get_jail_prop children_max $name)" \
+        allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
+        allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
+        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
+        allow.chflags="$(__get_jail_prop allow_chflags $name)" \
+        allow.mount="$(__get_jail_prop allow_mount $name)" \
+        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
+        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
+        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
+        allow.mount.tmpfs="$(__get_jail_prop allow_mount_tmpfs $name)" \
+        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
+        allow.quotas="$(__get_jail_prop allow_quotas $name)" \
+        allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
+        exec.prestart="$(__findscript $name prestart)" \
+        exec.poststart="$(__findscript $name poststart)" \
+        exec.prestop="$(__findscript $name prestop)" \
+        exec.stop="$(__get_jail_prop exec_stop $name)" \
+        exec.clean="$(__get_jail_prop exec_clean $name)" \
+        exec.timeout="$(__get_jail_prop exec_timeout $name)" \
+        stop.timeout="$(__get_jail_prop stop_timeout $name)" \
+        mount.fstab="/iocage/jails/$name/fstab" \
+        mount.devfs="$(__get_jail_prop mount_devfs $name)" \
+        mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
+        allow.dying \
+        exec.consolelog="/iocage/log/${name}-console.log" \
+        persist
+    fi
 }
 
 __stop_jail () {


### PR DESCRIPTION
Legacy start fails on hosts that do not have IPv6 enabled. The issue is that jail -c will throw an error if the parameter key is invalid (there no sysctl OID to back it up).

This PR adds a test to see if IPv6 is available and omits the corresponding parameters from the jail -c call.