### PR TITLE
iocroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,26 @@ I'll see myself out...
 
 For instance, my zpool named 'neuralnet' looks like this when zfs list:
 (lololololol you get the idea)
-	# zfs list
-	NAME USED  AVAIL  REFER  MOUNTPOINT
-	neuralnet	
-	neuralnet/vbox
-	neuralnet/ezjail
-	neuralnet/iocage
-	neuralnet/thewarden
-	ZROOT                781M  93.2G   144K  none
-	ZROOT/ROOT           777M  93.2G   144K  none
-	ZROOT/ROOT/default   777M  93.2G   777M  /
-	ZROOT/tmp            176K  93.2G   176K  /tmp
-	ZROOT/usr            616K  93.2G   144K  /usr
-	ZROOT/usr/home       184K  93.2G   184K  /usr/home
-	ZROOT/usr/ports      144K  93.2G   144K  /usr/ports
-	ZROOT/usr/src        144K  93.2G   144K  /usr/src
-	ZROOT/var           1.20M  93.2G   608K  /var
-	ZROOT/var/crash      148K  93.2G   148K  /var/crash
-	ZROOT/var/log        178K  93.2G   178K  /var/log
-	ZROOT/var/mail       144K  93.2G   144K  /var/mail
-	ZROOT/var/tmp        152K  93.2G   152K  /var/tmp
+        # zfs list
+        NAME USED  AVAIL  REFER  MOUNTPOINT
+        neuralnet	
+        neuralnet/vbox
+        neuralnet/ezjail
+        neuralnet/iocage
+        neuralnet/thewarden
+        ZROOT                781M  93.2G   144K  none
+        ZROOT/ROOT           777M  93.2G   144K  none
+        ZROOT/ROOT/default   777M  93.2G   777M  /
+        ZROOT/tmp            176K  93.2G   176K  /tmp
+        ZROOT/usr            616K  93.2G   144K  /usr
+        ZROOT/usr/home       184K  93.2G   184K  /usr/home
+        ZROOT/usr/ports      144K  93.2G   144K  /usr/ports
+        ZROOT/usr/src        144K  93.2G   144K  /usr/src
+        ZROOT/var           1.20M  93.2G   608K  /var
+        ZROOT/var/crash      148K  93.2G   148K  /var/crash
+        ZROOT/var/log        178K  93.2G   178K  /var/log
+        ZROOT/var/mail       144K  93.2G   144K  /var/mail
+        ZROOT/var/tmp        152K  93.2G   152K  /var/tmp
  
 
 **FEATURES:**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ I'll see myself out...
 
 For instance, my zpool named 'neuralnet' looks like this when zfs list:
 (lololololol you get the idea)
+
         # zfs list
         NAME USED  AVAIL  REFER  MOUNTPOINT
         neuralnet	

--- a/README.md
+++ b/README.md
@@ -20,26 +20,26 @@ I'll see myself out...
 
 For instance, my zpool named 'neuralnet' looks like this when zfs list:
 (lololololol you get the idea)
-# zfs list
-NAME USED  AVAIL  REFER  MOUNTPOINT
-neuralnet	
-neuralnet/vbox
-neuralnet/ezjail
-neuralnet/iocage
-neuralnet/thewarden
-ZROOT                781M  93.2G   144K  none
-ZROOT/ROOT           777M  93.2G   144K  none
-ZROOT/ROOT/default   777M  93.2G   777M  /
-ZROOT/tmp            176K  93.2G   176K  /tmp
-ZROOT/usr            616K  93.2G   144K  /usr
-ZROOT/usr/home       184K  93.2G   184K  /usr/home
-ZROOT/usr/ports      144K  93.2G   144K  /usr/ports
-ZROOT/usr/src        144K  93.2G   144K  /usr/src
-ZROOT/var           1.20M  93.2G   608K  /var
-ZROOT/var/crash      148K  93.2G   148K  /var/crash
-ZROOT/var/log        178K  93.2G   178K  /var/log
-ZROOT/var/mail       144K  93.2G   144K  /var/mail
-ZROOT/var/tmp        152K  93.2G   152K  /var/tmp
+	# zfs list
+	NAME USED  AVAIL  REFER  MOUNTPOINT
+	neuralnet	
+	neuralnet/vbox
+	neuralnet/ezjail
+	neuralnet/iocage
+	neuralnet/thewarden
+	ZROOT                781M  93.2G   144K  none
+	ZROOT/ROOT           777M  93.2G   144K  none
+	ZROOT/ROOT/default   777M  93.2G   777M  /
+	ZROOT/tmp            176K  93.2G   176K  /tmp
+	ZROOT/usr            616K  93.2G   144K  /usr
+	ZROOT/usr/home       184K  93.2G   184K  /usr/home
+	ZROOT/usr/ports      144K  93.2G   144K  /usr/ports
+	ZROOT/usr/src        144K  93.2G   144K  /usr/src
+	ZROOT/var           1.20M  93.2G   608K  /var
+	ZROOT/var/crash      148K  93.2G   148K  /var/crash
+	ZROOT/var/log        178K  93.2G   178K  /var/log
+	ZROOT/var/mail       144K  93.2G   144K  /var/mail
+	ZROOT/var/tmp        152K  93.2G   152K  /var/tmp
  
 
 **FEATURES:**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-iocage
+iocage Pool Party
 ======
 
 **FreeBSD jail manager**
@@ -7,10 +7,40 @@ iocage is a zero dependency drop in jail/container manager amalgamating some
 of the best features and technologies the FreeBSD operating system has to offer.
 It is geared for ease of use with a simple and easy to understand command syntax.
 
-Iocage is in the FreeBSD ports tree.
-To install simply run: `pkg install iocage`
+iocage is designed to wield the awesome power of iocage, but allow it to be installed on a
+ZFS pool that has multiple types of virtualization platforms housing data in separte datasets. 
 
-- **[DOCUMENTATION](http://iocage.readthedocs.org/en/latest/index.html)**
+Basically, I am hacking at iocage as to allow it's use in the virtualization solution I use 
+in all my FreeBSD virtualization servers. 
+
+This iocage version might be out of date, so beware. 
+
+In other words, everyone is invited to the zpool party! \o/
+I'll see myself out...
+
+For instance, my zpool named 'neuralnet' looks like this when zfs list:
+(lololololol you get the idea)
+# zfs list
+NAME USED  AVAIL  REFER  MOUNTPOINT
+neuralnet	
+neuralnet/vbox
+neuralnet/ezjail
+neuralnet/iocage
+neuralnet/thewarden
+ZROOT                781M  93.2G   144K  none
+ZROOT/ROOT           777M  93.2G   144K  none
+ZROOT/ROOT/default   777M  93.2G   777M  /
+ZROOT/tmp            176K  93.2G   176K  /tmp
+ZROOT/usr            616K  93.2G   144K  /usr
+ZROOT/usr/home       184K  93.2G   184K  /usr/home
+ZROOT/usr/ports      144K  93.2G   144K  /usr/ports
+ZROOT/usr/src        144K  93.2G   144K  /usr/src
+ZROOT/var           1.20M  93.2G   608K  /var
+ZROOT/var/crash      148K  93.2G   148K  /var/crash
+ZROOT/var/log        178K  93.2G   178K  /var/log
+ZROOT/var/mail       144K  93.2G   144K  /var/mail
+ZROOT/var/tmp        152K  93.2G   152K  /var/tmp
+ 
 
 **FEATURES:**
 - rapid thin provisioning (within seconds!)

--- a/iocage
+++ b/iocage
@@ -30,7 +30,7 @@ unset LANG
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 
 if [ "${1}" = "--version" -o "${1}" = "version" ] ; then
-    echo "iocage 1.4.6 (2015/01/03)"
+    echo "iocage 1.4.7 (2015/03/02)"
     exit 0
 fi
 
@@ -128,6 +128,7 @@ shmsize="off"
 wallclock="off"
 
 # Custom properties
+iocroot="/neuralnet/iocage"
 tag=$(date "+%F@%T")
 template="no"
 boot="off"
@@ -451,7 +452,7 @@ __fetch_release () {
 
     if [ -z "$exist" ] ; then
         zfs create $pool/iocage
-        zfs set mountpoint=/iocage $pool/iocage
+        zfs set mountpoint=$iocroot $pool/iocage
         zfs create $pool/iocage/jails
         zfs mount -a
     fi 
@@ -462,7 +463,7 @@ __fetch_release () {
 
     ftpdir="/pub/FreeBSD/releases/amd64/$release"
 
-    cd /iocage/download/$release
+    cd $iocroot/download/$release
     for file in $ftpfiles ; do
         if [ ! -e "$file" ] ; then        
             fetch http://$ftphost$ftpdir/$file
@@ -476,17 +477,17 @@ __fetch_release () {
     for file in $(echo $ftpfiles) ; do
         if [ -e "$file" ] ; then
             echo "Extracting: $file"
-            tar -C /iocage/releases/$release/root -xf $file
+            tar -C $iocroot/releases/$release/root -xf $file
         fi
     done
     
         echo "* Updating base jail.."
         sleep 2
-        env UNAME_r="$release" /usr/sbin/freebsd-update -b /iocage/releases/$release/root -d /iocage/releases/$release/root/var/db/freebsd-update/ fetch
-        env UNAME_r="$release" /usr/sbin/freebsd-update -b /iocage/releases/$release/root -d /iocage/releases/$release/root/var/db/freebsd-update/ install
+        env UNAME_r="$release" /usr/sbin/freebsd-update -b $iocroot/releases/$release/root -d $iocroot/releases/$release/root/var/db/freebsd-update/ fetch
+        env UNAME_r="$release" /usr/sbin/freebsd-update -b $iocroot/releases/$release/root -d $iocroot/releases/$release/root/var/db/freebsd-update/ install
     
-    if [ ! -d /iocage/log ] ; then 
-        mkdir /iocage/log
+    if [ ! -d $iocroot/log ] ; then 
+        mkdir $iocroot/log
     fi
 }
 
@@ -519,14 +520,14 @@ __create_jail () {
     fi
 
     __configure_jail $pool/iocage/jails/$uuid
-    touch /iocage/jails/$uuid/fstab
+    touch $iocroot/jails/$uuid/fstab
 
     # at create time set the default rc.conf
     if [ "${2}" != "-e" ] ; then
-        echo "hostname=${uuid}" > /iocage/jails/${uuid}/root/etc/rc.conf
+        echo "hostname=${uuid}" > $iocroot/jails/${uuid}/root/etc/rc.conf
         __jail_rc_conf >> \
-        /iocage/jails/${uuid}/root/etc/rc.conf
-        __resolv_conf > /iocage/jails/${uuid}/root/etc/resolv.conf
+        $iocroot/jails/${uuid}/root/etc/rc.conf
+        __resolv_conf > $iocroot/jails/${uuid}/root/etc/resolv.conf
     elif [ "${2}" = "-e" ] ; then
         echo $uuid
     fi
@@ -538,7 +539,7 @@ __create_jail () {
     # Install extra packages
     # this requires working resolv.conf in jail
     if [ "$pkglist" != "none" ] ; then
-        __pkg_install "/iocage/jails/${uuid}/root"
+        __pkg_install "$iocroot/jails/${uuid}/root"
     fi
 }
 
@@ -580,15 +581,15 @@ __clone_jail () {
     fi
 
     __configure_jail $pool/iocage/jails/$uuid
-    mv /iocage/jails/$uuid/fstab /iocage/jails/$uuid/fstab.$name
-    touch /iocage/jails/$uuid/fstab
+    mv $iocroot/jails/$uuid/fstab $iocroot/jails/$uuid/fstab.$name
+    touch $iocroot/jails/$uuid/fstab
 
-    cat /iocage/jails/${uuid}/root/etc/rc.conf | \
+    cat $iocroot/jails/${uuid}/root/etc/rc.conf | \
     sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/$uuid/g" \
-    > /iocage/jails/${uuid}/rc.conf
+    > $iocroot/jails/${uuid}/rc.conf
 
-    mv /iocage/jails/${uuid}/rc.conf \
-    /iocage/jails/${uuid}/root/etc/rc.conf
+    mv $iocroot/jails/${uuid}/rc.conf \
+    $iocroot/jails/${uuid}/root/etc/rc.conf
 }
 
 # Destroy jails --------------------------------------------------------------
@@ -957,7 +958,7 @@ __start_jail () {
     fi
 
     if [ "$procfs" == "1" ] ; then
-        mount -t procfs proc /iocage/jails/${fulluuid}/root/proc
+        mount -t procfs proc $iocroot/jails/${fulluuid}/root/proc
     fi
 
     local jzfs="$(__get_jail_prop jail_zfs $fulluuid)"
@@ -1023,7 +1024,7 @@ __start_jail () {
 
     echo -n "  + Starting services" 
     jexec ioc-${fulluuid} $(__get_jail_prop exec_start $fulluuid) \
-     >> /iocage/log/${fulluuid}-console.log 2>&1
+     >> $iocroot/log/${fulluuid}-console.log 2>&1
 
     if [ $? -eq 1 ] ; then
         echo "        FAILED"
@@ -1072,11 +1073,11 @@ __vnet_start () {
     exec.clean="$(__get_jail_prop exec_clean $name)" \
     exec.timeout="$(__get_jail_prop exec_timeout $name)" \
     stop.timeout="$(__get_jail_prop stop_timeout $name)" \
-    mount.fstab="/iocage/jails/$name/fstab" \
+    mount.fstab="$iocroot/jails/$name/fstab" \
     mount.devfs="$(__get_jail_prop mount_devfs $name)" \
     mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
     allow.dying \
-    exec.consolelog="/iocage/log/${name}-console.log" \
+    exec.consolelog="$iocroot/log/${name}-console.log" \
     persist
 }
 
@@ -1130,11 +1131,11 @@ __legacy_start () {
         exec.clean="$(__get_jail_prop exec_clean $name)" \
         exec.timeout="$(__get_jail_prop exec_timeout $name)" \
         stop.timeout="$(__get_jail_prop stop_timeout $name)" \
-        mount.fstab="/iocage/jails/$name/fstab" \
+        mount.fstab="$iocroot/jails/$name/fstab" \
         mount.devfs="$(__get_jail_prop mount_devfs $name)" \
         mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
         allow.dying \
-        exec.consolelog="/iocage/log/${name}-console.log" \
+        exec.consolelog="$iocroot/log/${name}-console.log" \
         persist
     else
         jail -c \
@@ -1168,11 +1169,11 @@ __legacy_start () {
         exec.clean="$(__get_jail_prop exec_clean $name)" \
         exec.timeout="$(__get_jail_prop exec_timeout $name)" \
         stop.timeout="$(__get_jail_prop stop_timeout $name)" \
-        mount.fstab="/iocage/jails/$name/fstab" \
+        mount.fstab="$iocroot/jails/$name/fstab" \
         mount.devfs="$(__get_jail_prop mount_devfs $name)" \
         mount.fdescfs="$(__get_jail_prop mount_fdescfs $name)" \
         allow.dying \
-        exec.consolelog="/iocage/log/${name}-console.log" \
+        exec.consolelog="$iocroot/log/${name}-console.log" \
         persist
     fi
 }
@@ -1223,7 +1224,7 @@ __stop_jail () {
 
     echo -n "  + Stopping services"
 
-    jexec ioc-${fulluuid} $exec_stop >> /iocage/log/${fulluuid}-console.log 2>&1
+    jexec ioc-${fulluuid} $exec_stop >> $iocroot/log/${fulluuid}-console.log 2>&1
 
     if [ $? -ne 1 ] ; then
         echo "        OK"
@@ -1260,13 +1261,13 @@ __stop_jail () {
         echo "    FAILED"
     fi
 
-    umount -afvF /iocage/jails/${fulluuid}/fstab > /dev/null 2>&1
-    umount /iocage/jails/${fulluuid}/root/dev/fd > /dev/null 2>&1
-    umount /iocage/jails/${fulluuid}/root/dev    > /dev/null 2>&1
-    umount /iocage/jails/${fulluuid}/root/proc   > /dev/null 2>&1
+    umount -afvF $iocroot/jails/${fulluuid}/fstab > /dev/null 2>&1
+    umount $iocroot/jails/${fulluuid}/root/dev/fd > /dev/null 2>&1
+    umount $iocroot/jails/${fulluuid}/root/dev    > /dev/null 2>&1
+    umount $iocroot /jails/${fulluuid}/root/proc   > /dev/null 2>&1
 
-    if [ -d /iocage/jails/${fulluuid}/recorded ] ; then
-        umount -ft unionfs /iocage/jails/${fulluuid}/root > /dev/null 2>&1
+    if [ -d $iocroot/jails/${fulluuid}/recorded ] ; then
+        umount -ft unionfs $iocroot/jails/${fulluuid}/root > /dev/null 2>&1
     fi
 
     if [ ! -z $(sysctl -qn kern.features.rctl) ] ; then
@@ -1305,11 +1306,11 @@ __restart_jail () {
     local tag="$(__get_jail_prop tag $fulluuid)"
 
     echo "* Soft restarting $fulluuid ($tag)"
-    jexec ioc-${fulluuid} $exec_stop >> /iocage/log/${fulluuid}-console.log 2>&1
+    jexec ioc-${fulluuid} $exec_stop >> $iocroot/log/${fulluuid}-console.log 2>&1
 
     if [ $? -ne "1" ] ; then
         pkill -j $jid
-        jexec ioc-${fulluuid} $exec_start >> /iocage/log/${fulluuid}-console.log 2>&1
+        jexec ioc-${fulluuid} $exec_start >> $iocroot/log/${fulluuid}-console.log 2>&1
         zfs set org.freebsd.iocage:last_started=$(date "+%F_%T") $dataset
     else
         echo "  ERROR: soft restart failed.."
@@ -1701,7 +1702,7 @@ __chroot () {
 
     local fulluuid="$(__check_name $name)"
 
-    chroot /iocage/jails/${fulluuid}/root $command
+    chroot $iocroot/jails/${fulluuid}/root $command
 }
 
 
@@ -2024,7 +2025,7 @@ __record () {
         fi
 
     elif [ $action == "stop" ] ; then
-        umount -ft unionfs /iocage/jails/${fulluuid}/root > /dev/null 2>&1
+        umount -ft unionfs $iocroot/jails/${fulluuid}/root > /dev/null 2>&1
         echo "* Stopped recording to: ${mountpoint}/recorded"
 
         find ${mountpoint}/recorded/ -type d -empty -exec rm -rf {} \; \
@@ -2070,15 +2071,15 @@ __package () {
         exit 1
     fi
 
-    if [ ! -d "/iocage/packages" ] ; then
-        mkdir /iocage/packages
+    if [ ! -d "$iocroot/packages" ] ; then
+        mkdir $iocroot/packages
     fi
 
     echo "* Creating package..."
-    tar -cvJf /iocage/packages/$fulluuid.tar.xz -C ${mountpoint}/recorded . && \
-    sha256 -q /iocage/packages/$fulluuid.tar.xz > /iocage/packages/$fulluuid.sha256
-    echo "* Package saved to: /iocage/packages/$fulluuid.tar.xz"
-    echo "* Checksum created: /iocage/packages/$fulluuid.sha256"
+    tar -cvJf $iocroot/packages/$fulluuid.tar.xz -C ${mountpoint}/recorded . && \
+    sha256 -q $iocroot/packages/$fulluuid.tar.xz > $iocroot/packages/$fulluuid.sha256
+    echo "* Package saved to: $iocroot/packages/$fulluuid.tar.xz"
+    echo "* Checksum created: $iocroot/packages/$fulluuid.sha256"
 }
 
 __import () {
@@ -2089,8 +2090,8 @@ __import () {
         exit 1
     fi
 
-    local package="$(find /iocage/packages/ -name $name\*.tar.xz)"
-    local image="$(find /iocage/images/ -name $name\*.tar.xz)"
+    local package="$(find $iocroot/packages/ -name $name\*.tar.xz)"
+    local image="$(find $iocroot/images/ -name $name\*.tar.xz)"
     local pcount="$(echo $package|wc -w)"
     local icount="$(echo $image|wc -w)"
 
@@ -2098,14 +2099,14 @@ __import () {
         echo "  ERROR: multiple matching packages, please narrow down UUID."
         exit 1
     elif [ $pcount -eq 1 ] ; then
-        local pcksum="$(find /iocage/packages/ -name $name\*.sha256)"
+        local pcksum="$(find $iocroot/packages/ -name $name\*.sha256)"
     fi
 
     if [ $icount -gt 1 ] ; then
         echo "  ERROR: multiple matching images, please narrow down UUID."
         exit 1
     elif [ $icount -eq 1 ] ; then
-        local icksum="$(find /iocage/images/ -name $name\*.sha256)"
+        local icksum="$(find $iocroot/images/ -name $name\*.sha256)"
     fi
 
     if [ $pcount -gt 0 ] && [ $icount -gt 0 ] ; then
@@ -2160,12 +2161,12 @@ __import () {
         exit 1
     fi
 
-    cat /iocage/jails/${uuid}/root/etc/rc.conf | \
+    cat $iocroot/jails/${uuid}/root/etc/rc.conf | \
     sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/$uuid/g" \
-    > /iocage/jails/${uuid}/rc.conf
+    > $iocroot/jails/${uuid}/rc.conf
 
-    mv /iocage/jails/${uuid}/rc.conf \
-    /iocage/jails/${uuid}/root/etc/rc.conf
+    mv $iocroot/jails/${uuid}/rc.conf \
+    $iocroot/jails/${uuid}/root/etc/rc.conf
 }
 
 __export () {
@@ -2201,15 +2202,15 @@ __export () {
 
     local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
 
-    if [ ! -d "/iocage/images" ] ; then
-        mkdir /iocage/images
+    if [ ! -d "$iocroot/images" ] ; then
+        mkdir $iocroot/images
     fi
 
     echo "* Exporting $fulluuid .."
-    tar -cvJf /iocage/images/$fulluuid.tar.xz -C ${mountpoint}/root . && \
-    sha256 -q /iocage/images/$fulluuid.tar.xz > /iocage/images/$fulluuid.sha256
-    echo "* Image saved to: /iocage/images/$fulluuid.tar.xz"
-    echo "* Checksum created: /iocage/images/$fulluuid.sha256"
+    tar -cvJf $iocroot/images/$fulluuid.tar.xz -C ${mountpoint}/root . && \
+    sha256 -q $iocroot/images/$fulluuid.tar.xz > $iocroot/images/$fulluuid.sha256
+    echo "* Image saved to: $iocroot/images/$fulluuid.tar.xz"
+    echo "* Checksum created: $iocroot/images/$fulluuid.sha256"
 
 }
 
@@ -2240,7 +2241,7 @@ __check_name () {
 }
 
 # reads tag property from given jail dataset
-# creates symlink from /iocage/tags/<tag> to /iocage/jails/<uuid>
+# creates symlink from $iocroot/tags/<tag> to $iocroot/jails/<uuid>
 __link_tag () {
     local dataset=$1
     local mountpoint
@@ -2248,9 +2249,9 @@ __link_tag () {
 
     if mountpoint=$(zfs get -H -o value mountpoint $dataset) ; then
         if tag=$(zfs get -H -o value org.freebsd.iocage:tag $dataset); then
-            mkdir -p /iocage/tags
-            if [ ! -e /iocage/tags/$tag ] ; then
-                ln -s $mountpoint /iocage/tags/$tag
+            mkdir -p $iocroot/tags
+            if [ ! -e $iocroot/tags/$tag ] ; then
+                ln -s $mountpoint $iocroot/tags/$tag
             else
                 echo "  ERROR: tag already exists, can not symlink: $tag"
                 exit 1
@@ -2262,13 +2263,13 @@ __link_tag () {
     fi
 }
 
-# removes all symlinks found in /iocage/tags pointing to the given jail dataset
+# removes all symlinks found in $iocroot/tags pointing to the given jail dataset
 __unlink_tag () {
     local dataset=$1
     local mountpoint
 
     if mountpoint=$(zfs get -H -o value mountpoint $dataset) ; then
-        find /iocage/tags -type l -lname "${mountpoint}*" -exec rm -f \{\} \;
+        find $iocroot/tags -type l -lname "${mountpoint}*" -exec rm -f \{\} \;
     fi
 }
 

--- a/iocage
+++ b/iocage
@@ -128,7 +128,7 @@ shmsize="off"
 wallclock="off"
 
 # Custom properties
-iocroot="/neuralnet/iocage"
+iocroot="/iocage"
 tag=$(date "+%F@%T")
 template="no"
 boot="off"


### PR DESCRIPTION
Changed instances of '/iocage' to '$iocroot' to allow storage of iocage stuff elsewhere. 
Nothing too fancy. 
$iocroot is set to /iocage by default.