### PR TITLE
Made the basejail jails use readonly

### DIFF
--- a/iocage
+++ b/iocage
@@ -580,8 +580,9 @@ __create_jail () {
        zfs create -p $pool/iocage/jails/$uuid/root/usr
 
        for fs in $bfs_list ; do
-           zfs clone $pool/iocage/base/${release}/root/$fs@$uuid \
-                     $pool/iocage/jails/$uuid/root/$fs
+           zfs clone -o readonly=on \
+           $pool/iocage/base/${release}/root/$fs@$uuid \
+           $pool/iocage/jails/$uuid/root/$fs
        done
 
        for dir in $bdir_list ; do


### PR DESCRIPTION
No reason to be writing to the directories as they will be lost. This makes it more clear to the user when you are unable to do so at all.