### PR TITLE
Fix hardcoded zroot pool.

### DIFF
--- a/iocage
+++ b/iocage
@@ -1468,7 +1468,7 @@ __list_jails () {
 
     if [ ! -z ${switch} ] && [ $switch == "-r" ] ; then
         echo "Downloaded releases:"
-        local releases="$(zfs list -o name -Hr zroot/iocage/releases \
+        local releases="$(zfs list -o name -Hr $pool/iocage/releases \
                         | grep RELEASE$ | cut -d \/ -f 4)"
         for rel in $(echo $releases) ; do
             printf "%15s\n" "$rel"


### PR DESCRIPTION
Had a hardcoded variable that does not work with different pool names.