### PR TITLE
Detect if ZFS is available and exit if it isnt

### DIFF
--- a/iocage
+++ b/iocage
@@ -34,6 +34,13 @@ if [ "${1}" = "--version" -o "${1}" = "version" ] ; then
     exit 0
 fi
 
+# Check is the system has ZFS that is required for iocage to work properly
+# and exit if it doesn't
+if [ "$(zpool list)" = 'no pools available' ] ; then
+    echo "  ERROR: ZFS is required for iocage to work and I can't finy any pools available."
+    exit 1
+fi
+
 # Auto UUID
 uuid=$(uuidgen)
 


### PR DESCRIPTION
Currently iocage requires ZFS to work properly, however, it doesnt exit nor stop any actions if it is being used on a host without ZFS available, resulting in cluttered, broken setup of iocage environment on the host OS. This change checks if there are any zpools available before doing anything.