### PR TITLE
show jid in "iocage list" and non iocage jails

### DIFF
--- a/iocage
+++ b/iocage
@@ -1538,6 +1538,7 @@ __list_jails () {
         jail_path=$(zfs get -H -o value mountpoint $jail)
         state=$(jls | grep ${jail_path} | awk '{print$1}')
         template=$(zfs get -H -o value org.freebsd.iocage:template $jail)
+        # get jid for iocage jails
         jid=$(jls -j "ioc-"$uuid  -h jid 2> /dev/null | grep -v -x "jid")
         if [ -z "$jid"  ] ; then
             jid="-"
@@ -1567,6 +1568,7 @@ __list_jails () {
         fi
     done
 
+    # create list of active jids not registered in iocage
     for all_jail in $all_jids ; do
         for ioc_jail in $ioc_jids ; do
             if [ "$all_jail" == "$ioc_jail" ] ; then
@@ -1581,6 +1583,8 @@ __list_jails () {
         local non_ioc_jids=$non_ioc_jids" "$temp_loop_var
     fi
     done
+
+    # output non iocage jails currently active
     if [ -n "$non_ioc_jids" ] ; then
         if [ $switch != "-t" ] ; then
             if [ $template != "yes" ] ; then

--- a/iocage
+++ b/iocage
@@ -1557,7 +1557,7 @@ __list_jails () {
 
         if [ $switch == "-t" ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-4s  %-+.36s  %-4s   %-4s   %s\n" "----" "$uuid" \
+                printf "%-+.36s %-3s %-4s %s\n" "$uuid" \
                 "$boot" "$state" "$tag"
             fi
         elif [ $switch != "-t" ] ; then
@@ -2755,7 +2755,7 @@ SUBCOMMANDS
 
     List all jails, if -t is specified list only templates, with -r list downloaded 
     releases.
-    Non iocage jails listed, only if in UP state.
+    Non iocage jail listed, only if jail in UP state.
 
   df
 

--- a/iocage
+++ b/iocage
@@ -1557,7 +1557,7 @@ __list_jails () {
 
         if [ $switch == "-t" ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-+.36s %-3s %-4s %s\n" "$uuid" \
+                printf "%-+.36s  %-3s   %-4s   %s\n" "$uuid" \
                 "$boot" "$state" "$tag"
             fi
         elif [ $switch != "-t" ] ; then

--- a/iocage
+++ b/iocage
@@ -1557,7 +1557,7 @@ __list_jails () {
 
         if [ $switch == "-t" ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-+.36s  %-3s   %-4s   %s\n" "$uuid" \
+                printf "%-4s  %-+.36s  %-3s   %-4s   %s\n" "$jid" "$uuid" \
                 "$boot" "$state" "$tag"
             fi
         elif [ $switch != "-t" ] ; then
@@ -1587,18 +1587,16 @@ __list_jails () {
     # output non iocage jails currently active
     if [ -n "$non_ioc_jids" ] ; then
         if [ $switch != "-t" ] ; then
-            if [ $template != "yes" ] ; then
-                printf "%-+40s\n" "--- non iocage jails currently active ---"
-                printf "%-4s  %-36s  %-15s  %s \n" "JID" "PATH"\
-                      "IP4" "HOSTNAME"
-                for jid in $non_ioc_jids ; do
-                    path=$(jls -j $jid  -h path | grep -v -x "path")
-                    ip4=$(jls -j $jid  -h ip4.addr | grep -v -x "ip4.addr")
-                    host_hostname=$(jls -j $jid  -h host.hostname | grep -v -x "host.hostname")
-                    printf "%-4s  %-36.36s  %-15s  %s\n" "$jid" "$path"  \
-                            "$ip4" "$host_hostname"
-                done
-            fi
+            printf "%-+40s\n" "--- non iocage jails currently active ---"
+            printf "%-4s  %-36s  %-15s  %s \n" "JID" "PATH"\
+                  "IP4" "HOSTNAME"
+            for jid in $non_ioc_jids ; do
+                path=$(jls -j $jid  -h path | grep -v -x "path")
+                ip4=$(jls -j $jid  -h ip4.addr | grep -v -x "ip4.addr")
+                host_hostname=$(jls -j $jid  -h host.hostname | grep -v -x "host.hostname")
+                printf "%-4s  %-36.36s  %-15s  %s\n" "$jid" "$path"  \
+                        "$ip4" "$host_hostname"
+            done
         fi
     fi
 }


### PR DESCRIPTION
It could be reasonable to show jid in "iocage list".
Also it useful to show another non iocage, if it active.
I hope you agree with output format . Example below
```
root@dell:/usr/local/sbin # iocage list
JID   UUID                                  BOOT  STATE  TAG
2     c25243e2-d388-11e4-9b0c-5c260a44a29b  off   up     myjail
--- non iocage jails currently active---
JID   PATH                                  IP4              HOSTNAME 
3     /usr/jails2/t3                        10.154.241.39    t3
```