### PR TITLE
Unscrew this Makefile - it's way more complicated than it needs to be

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,9 @@
 #	Makefile
 #
 
-.include <bsd.own.mk>
-
 PREFIX?= /usr/local
+
 MAN=
-BINOWN=		root
-BINGRP=		wheel
-BINMODE=	0555
 BINDIR=$(PREFIX)/sbin
 FILESDIR=$(PREFIX)/lib/iocage
 RCDIR=$(PREFIX)/etc/rc.d
@@ -16,17 +12,19 @@ MANDIR=$(PREFIX)/man/man8
 MKDIR=mkdir
 
 PROG=	iocage
+SCRIPTS=iocage
+SCRIPTSDIR=${PREFIX}/BINDIR
 MAN=	$(PROG).8
+
+${PROG}:
+	@echo Nothing needs to be done for iocage.
 
 install:
 	$(MKDIR) -p $(BINDIR)
 	$(MKDIR) -p $(FILESDIR)
-	$(INSTALL) -m $(BINMODE) $(PROG) $(BINDIR)/
-	$(INSTALL) lib/* $(FILESDIR)/
-	$(INSTALL) rc.d/* $(RCDIR)/
-	rm -f $(MAN).gz
-	gzip -k $(MAN)
-	$(INSTALL) $(MAN).gz $(MANDIR)/
-	rm -f $(MAN).gz
+	$(INSTALL) -c -m $(BINMODE) ${.OBJDIR}/$(PROG) $(BINDIR)/
+	$(INSTALL) -c ${.OBJDIR}/lib/* $(FILESDIR)/
+	$(INSTALL) -c ${.OBJDIR}/rc.d/* $(RCDIR)/
+	$(INSTALL) -c $(MAN).gz $(MANDIR)/
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
... and fell over frequently in a BSD universe.

This simplifies it, makes the default target work, and also installs iocage without removing it from your source directory :) 
