### PR TITLE
Shorten list of jails to start.

### DIFF
--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -543,10 +543,12 @@ __rc_jails () {
         local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
                     $jail)"
         local boot="$(zfs get -H -o value org.freebsd.iocage:boot $jail)"
+        local _jail_hostid="$(zfs get -H -o value org.freebsd.iocage:hostid \
+                    $jail)"
         local priority="$(zfs get -H -o value org.freebsd.iocage:priority \
-                        $jail)"
+                    $jail)"
 
-        if [ "$boot" == "on" ] ; then
+        if [ "$boot" == "on" -a "$_jail_hostid" == "$hostid" ; then
             echo "${priority},${name}" >> $boot_list
         fi
     done
@@ -555,7 +557,8 @@ __rc_jails () {
         local boot_order=$(sort -n $boot_list)
         local shutdown_order=$(sort -rn $boot_list)
     else
-        __info "no jails found with property boot=on, exiting.."
+        __info "no jails found with property boot=on”
+        echo “  or hostid: $hostid, exiting.."
         exit 0
     fi
 

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -548,7 +548,7 @@ __rc_jails () {
         local priority="$(zfs get -H -o value org.freebsd.iocage:priority \
                     $jail)"
 
-        if [ "$boot" == "on" -a "$_jail_hostid" == "$hostid" ; then
+        if [ "$boot" == "on" -a "$_jail_hostid" == "$hostid" ]; then
             echo "${priority},${name}" >> $boot_list
         fi
     done


### PR DESCRIPTION
Second try. please remove the first one #222
If a iocage server hold backups of other servers the server will try to
start them all. Even if we know they won’t start.
This change create a list of jails that match the hosted of the host
and the jail. If they match the jail is started, else it discards the
jail.
