### PR TITLE
Ignore .defaults directory

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -38,7 +38,7 @@ __set_jail_prop () {
     # Avoid having a stale list when called.
     export jail_datasets="$(zfs list -d3 -rH -o name ${pool}/iocage \
         | egrep -v \
-        "jails$|releases$|templates$|download|${pool}/iocage$|*./root")"
+        "jails$|releases$|templates$|download|.defaults|${pool}/iocage$|*./root")"
 
     if [ "$3" ] ; then
         _dataset="$3"
@@ -241,7 +241,7 @@ __set_jail_prop () {
                 # We need to ignore a few more datasets here.
                 _jail_datasets="$(zfs list -d3 -rH -o name \
                     ${pool}/iocage | egrep -v \
-                    "jails$|base|releases|templates$|download|${pool}/iocage$|*./root")"
+                    "jails$|base|releases|templates$|download|.defaults|${pool}/iocage$|*./root")"
 
                 for _fs in ${_jail_datasets} ; do
                     # _jail_fs is actually a dataset, so fulluuid needs to

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -66,7 +66,7 @@ __find_jail () {
 
     # shellcheck disable=SC2154,SC2155
     export jail_datasets="$(zfs list -d3 -rH -o name "${pool}/iocage" \
-        | egrep -v "jails$|base|releases|templates$|download|${pool}/iocage$|*./root|*./data")"
+        | egrep -v "jails$|base|releases|templates$|download|.defaults|${pool}/iocage$|*./root|*./data")"
 
     if [ "${_name}" = "ALL" ] ; then
         for _jail in ${jail_datasets} ; do

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -239,7 +239,7 @@ __migrate_basejail () {
     _ofulluuid="${_fulluuid}"
     _release="$2"
     _orelease="${_release}"
-    _grepstring="jails$|base|releases|templates$|download|${pool}/iocage$"
+    _grepstring="jails$|base|releases|templates$|download|.defaults|${pool}/iocage$"
     _grepstring="${_grepstring}|*./data|*./root"
     _bfs_list="bin
                boot
@@ -1031,7 +1031,7 @@ __check_children () {
 
     _fulluuid="$1"
     _dataset="$2"
-    _grepstring="jails$|base|releases|templates$|download|${pool}/iocage$"
+    _grepstring="jails$|base|releases|templates$|download|.defaults|${pool}/iocage$"
     _grepstring="${_grepstring}|*./data"
     _jail_datasets=$(zfs list -d3 -rH -o name "${pool}/iocage" \
         | egrep -v "${_grepstring}")


### PR DESCRIPTION
Newer iocage versions store their default configuration in a `.defaults` dataset. This dataset causes trouble when using iocage_legacy#develop on a system that shares jails of other versions.

This PR addresses an issue that @urosgruber has reported in [a comment on a libiocage issue](https://github.com/iocage/libiocage/issues/127#issuecomment-346025866).